### PR TITLE
fix: update to Node.js 22

### DIFF
--- a/cdk/Stack.ts
+++ b/cdk/Stack.ts
@@ -35,7 +35,7 @@ export class HTTPAPIMockStack extends Stack {
 				hash: layer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const httpMockApi = new HttpApiMock(this, {

--- a/cdk/resources/HttpApiMock.ts
+++ b/cdk/resources/HttpApiMock.ts
@@ -89,7 +89,7 @@ export class HttpApiMock extends Resource {
 			layers,
 			handler: lambdaSources.httpApiMock.handler,
 			architecture: Lambda.Architecture.ARM_64,
-			runtime: Lambda.Runtime.NODEJS_20_X,
+			runtime: Lambda.Runtime.NODEJS_22_X,
 			timeout: Duration.seconds(5),
 			environment: {
 				REQUESTS_TABLE_NAME: this.requestsTable.tableName,


### PR DESCRIPTION
See https://aws.amazon.com/de/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/
